### PR TITLE
refactor: update useDateUtils to accept locale as a MaybeRefOrGetter

### DIFF
--- a/app/composables/useDateUtils.ts
+++ b/app/composables/useDateUtils.ts
@@ -38,7 +38,7 @@ export function useDateUtils() {
     getDaysInPeriod: getDaysInPeriodShared,
 
     ...other
-  } = useDateUtilsShared(currentLocaleCode)
+  } = useDateUtilsShared(() => currentLocaleCode.value)
 
   function formatDate(
     dateRef?: MaybeRefOrGetter<Datetime>,

--- a/app/composables/useDateUtils.ts
+++ b/app/composables/useDateUtils.ts
@@ -27,7 +27,7 @@ export function getDateSimpleValue(dateRef: MaybeRefOrGetter<Datetime>) {
 }
 
 export function useDateUtils() {
-  const { currentLocale, getLocaleDateFormat } = useLocale()
+  const { currentLocale, currentLocaleCode, getLocaleDateFormat } = useLocale()
   const {
     formatDate: formatDateShared,
     formatTime: formatTimeShared,
@@ -38,7 +38,7 @@ export function useDateUtils() {
     getDaysInPeriod: getDaysInPeriodShared,
 
     ...other
-  } = useDateUtilsShared(currentLocale.value.code)
+  } = useDateUtilsShared(currentLocaleCode)
 
   function formatDate(
     dateRef?: MaybeRefOrGetter<Datetime>,

--- a/shared/composables/useDateUtils.ts
+++ b/shared/composables/useDateUtils.ts
@@ -1,6 +1,4 @@
 import type { ManipulateType, OpUnitType } from 'dayjs'
-import type { MaybeRefOrGetter } from 'vue'
-import { toValue } from 'vue'
 
 // Types
 import type { Period } from '../types/period.type'
@@ -30,9 +28,7 @@ export function getDateSimpleValue(date: Datetime) {
   return $date(date).startOf('day').valueOf()
 }
 
-export function useDateUtils(localeIsoRef: MaybeRefOrGetter<string>) {
-  const getLocaleIso = () => toValue(localeIsoRef)
-
+export function useDateUtils(getLocaleIso: () => string) {
   const localeUses24HourTime = () => {
     const localeIso = getLocaleIso()
 

--- a/shared/composables/useDateUtils.ts
+++ b/shared/composables/useDateUtils.ts
@@ -1,4 +1,6 @@
 import type { ManipulateType, OpUnitType } from 'dayjs'
+import type { MaybeRefOrGetter } from 'vue'
+import { toValue } from 'vue'
 
 // Types
 import type { Period } from '../types/period.type'
@@ -28,8 +30,12 @@ export function getDateSimpleValue(date: Datetime) {
   return $date(date).startOf('day').valueOf()
 }
 
-export function useDateUtils(localeIso: string) {
+export function useDateUtils(localeIsoRef: MaybeRefOrGetter<string>) {
+  const getLocaleIso = () => toValue(localeIsoRef)
+
   const localeUses24HourTime = () => {
+    const localeIso = getLocaleIso()
+
     return (
       new Intl.DateTimeFormat(localeIso, { hour: 'numeric' })
         .formatToParts(new Date(2020, 0, 1, 13))
@@ -49,6 +55,7 @@ export function useDateUtils(localeIso: string) {
 
     // When using a predefined format, we use the corresponding Intl API
     if (typeof options === 'string') {
+      const localeIso = getLocaleIso()
       const parsedDate = parseDate(date)
 
       if (!parsedDate.isValid()) {
@@ -67,11 +74,10 @@ export function useDateUtils(localeIso: string) {
           .replace(/(\d{2})\.\s(\d{2})\.\s(\d{4})/g, '$1.$2.$3')
       }
     }
-
     // Otherwise we use the Intl API
     else {
       const { outputIntlOptions } = options
-      const usedLocaleIso = options?.localeIso ?? localeIso
+      const usedLocaleIso = options?.localeIso ?? getLocaleIso()
       const parsedDate = parseDate(date, options)
 
       if (!parsedDate.isValid()) {

--- a/shared/utils/format-value.ts
+++ b/shared/utils/format-value.ts
@@ -117,7 +117,7 @@ export function formatValue(
     format,
   } = options ?? {}
 
-  const { formatDate, formatTime } = useDateUtilsShared(localeIso)
+  const { formatDate, formatTime } = useDateUtilsShared(() => localeIso)
   const { formatNumber } = useNumberShared({ localeIso })
   const { getDuration } = useDurationShared({ localeIso })
 


### PR DESCRIPTION
`useDateUtils()` passed `currentLocale.value.code` into the shared date utils as a plain string, so the locale was captured when the composable was created. When the user switched locale later, the date mask updated to the new locale format, but formatting could still be same.

Fix: use reactive `currentLocaleCode` and resolve it at format time so date formatting stays aligned with the active locale
